### PR TITLE
Update CDN usage for XMTP Browser SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,16 @@
 # XMTPDemo
+
+This simple demo shows how to connect to the XMTP network in a browser.
+
+The app uses [`ethers`](https://cdn.jsdelivr.net/npm/ethers@5.7.2/) and the
+[`@xmtp/browser-sdk`](https://github.com/xmtp/xmtp-js) loaded from a CDN.
+Include the SDK in your module script using:
+
+```html
+<script type="module">
+  import { Client } from 'https://cdn.jsdelivr.net/npm/@xmtp/browser-sdk@3.0.1/dist/index.js';
+  // your code here
+</script>
+```
+
+Open `index.html` in a modern browser to try the chat example.

--- a/index.html
+++ b/index.html
@@ -11,7 +11,6 @@
     input[type="text"] { width: 100%; }
   </style>
   <script src="https://cdn.jsdelivr.net/npm/ethers@5.7.2/dist/ethers.umd.min.js"></script>
-  <script src="https://unpkg.com/@xmtp/xmtp-js/dist/xmtp.min.js"></script>
 </head>
 <body>
   <h1>XMTP Chat Demo</h1>
@@ -30,7 +29,9 @@
     <div id="messages"></div>
   </div>
 
-  <script>
+  <script type="module">
+    import { Client } from 'https://cdn.jsdelivr.net/npm/@xmtp/browser-sdk@3.0.1/dist/index.js';
+
     let client;
 
     document.getElementById('connect').addEventListener('click', async () => {
@@ -41,7 +42,7 @@
       }
       try {
         const wallet = new ethers.Wallet(pk);
-        client = await xmtp.Client.create(wallet, { env: 'production' });
+        client = await Client.create(wallet, { env: 'production' });
         document.getElementById('chat').style.display = 'block';
       } catch (err) {
         console.error(err);


### PR DESCRIPTION
## Summary
- switch script to use `@xmtp/browser-sdk` from jsDelivr
- load SDK using `type="module"` and update example code
- document updated CDN usage in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6860529264dc832c9c4efd798f905ec1