### PR TITLE
Fix XMTP proto import for browser

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,6 +19,7 @@
         "@xmtp/content-type-primitives": "https://cdn.jsdelivr.net/npm/@xmtp/content-type-primitives@2.0.2/dist/browser/index.js",
         "@xmtp/content-type-text": "https://cdn.jsdelivr.net/npm/@xmtp/content-type-text@2.0.2/dist/browser/index.js",
         "@xmtp/wasm-bindings": "https://cdn.jsdelivr.net/npm/@xmtp/wasm-bindings@1.2.3/dist/bindings_wasm.js",
+        "@xmtp/proto": "https://cdn.jsdelivr.net/npm/@xmtp/proto@3.83.0/ts/dist/esm/index.js",
         "uuid": "https://cdn.jsdelivr.net/npm/uuid@11.1.0/+esm"
       }
     }


### PR DESCRIPTION
## Summary
- update the import map to include `@xmtp/proto`

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68605c31a0d4832c809d9d16d36ed6b6