### PR TITLE
Improve private key validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,6 @@ Include the SDK in your module script using:
 ```
 
 Open `index.html` in a modern browser to try the chat example.
+
+When entering your private key, you may include or omit the `0x` prefix.
+The input will be validated and trimmed automatically.

--- a/index.html
+++ b/index.html
@@ -67,8 +67,10 @@
     }
 
     connectBtn.onclick = async () => {
-      const pk = document.getElementById('privateKey').value.trim();
+      let pk = document.getElementById('privateKey').value.trim();
       if (!pk) return alert('請輸入私鑰');
+      pk = pk.replace(/^0x/i, '');
+      if (pk.length !== 64) return alert('私鑰需為 64 個十六進位字元');
       try {
         const wallet = new Wallet('0x' + pk);
         walletAddress = wallet.address;


### PR DESCRIPTION
## Summary
- trim optional `0x` prefix and check private key length
- update README with clarifications about the private key input

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6860c1c4f040832caa16b92a423c23d7